### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://disprojectteam.visualstudio.com/6c3081d5-d087-4098-9dc1-d8bc1b514bad/87b52159-7d37-49a3-8388-07017343f9a5/_apis/work/boardbadge/9993705d-0637-4efd-ac6f-dd207598d6a6)](https://disprojectteam.visualstudio.com/6c3081d5-d087-4098-9dc1-d8bc1b514bad/_boards/board/t/87b52159-7d37-49a3-8388-07017343f9a5/Microsoft.RequirementCategory)
 # Create React App example
 
 ## How to use


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#78](https://disprojectteam.visualstudio.com/6c3081d5-d087-4098-9dc1-d8bc1b514bad/_workitems/edit/78). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.